### PR TITLE
Reformat Changes to be MetaCPAN friendly

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,47 +1,48 @@
-String::Util
-    Version 0.10, December 1, 2005
+{{$NEXT}}
 
-      Initial release
+1.24  2014-12-31
 
-    Version 0.11, December 22, 2005
+      - Cleaned up POD formatting.
 
-      This is a non-backwards compatible version.
+      - Changed file to using Unixish style newlines. I hadn't realized until
+      now that it was using Windowish newline. How embarrasing.
 
-      urldecode, urlencode were removed entirely. All of the subs that used
+      - Added some features to ords().
+
+1.23
+
+      - Fixed error in META.yml.
+
+1.22
+
+      - Fix in documentation for randpost().
+
+      - Clarified documentation for hascontent() and nocontent().
+
+1.21  2012-07-18
+
+      - Fixed error in POD. Tightened up code for repet.
+
+1.20  2012-07-14
+
+      - Properly listing prerequisites.
+
+1.01  2010-11-07
+
+      - Decided it was time to upload five years worth of changes.
+
+0.11  2005-12-22
+
+      - This is a non-backwards compatible version.
+
+      - urldecode, urlencode were removed entirely. All of the subs that used
       to modify values in place were changed so that they do not do so
       anymore, except for fullchomp.
 
-      See
-      http://www.xray.mpe.mpg.de/mailing-lists/modules/2005-12/msg00112.htm
-      l for why these changes were made.
+      - See
+      http://www.xray.mpe.mpg.de/mailing-lists/modules/2005-12/msg00112.html
+      for why these changes were made.
 
-    Version 1.01, November 7, 2010
+0.10  2005-12-01
 
-      Decided it was time to upload five years worth of changes.
-
-    Version 1.20, July, 2012
-
-      Properly listing prerequisites.
-
-    Version 1.21, July 18, 2012
-
-      Fixed error in POD. Tightened up code for repet.
-
-    Version 1.22
-
-      Fix in documentation for randpost().
-
-      Clarified documentation for hascontent() and nocontent().
-
-    Version 1.23
-
-      Fixed error in META.yml.
-
-    Version 1.24, December 31, 2014
-
-      Cleaned up POD formatting.
-
-      Changed file to using Unixish style newlines. I hadn't realized until
-      now that it was using Windowish newline. How embarrasing.
-
-      Added some features to ords().
+      - Initial release


### PR DESCRIPTION
Changes for the next release should be placed after {{$NEXT}}, which the authoring tool will replace with the new version and release date upon running the release command.