### PR TITLE
Fix bug in string-containment functions

### DIFF
--- a/lib/String/Util.pm
+++ b/lib/String/Util.pm
@@ -605,7 +605,10 @@ Checks if the string contains substring
 
   $var = contains("Hello world", "Hello");   # true
   $var = contains("Hello world", "llo wor"); # true
+  $var = contains("Hello world", "");        # true
   $var = contains("Hello world", "QQQ");     # false
+  $var = contains(undef, "QQQ");             # false
+  $var = contains("Hello world", undef);     # false
 
   # Also works with grep
   @arr = grep { contains("cat") } @input;
@@ -613,16 +616,9 @@ Checks if the string contains substring
 =cut
 
 sub contains {
-	my ($str, $substr) = @_;
+	my ($str, $substr) = @_ == 1 ? ($_, $_[0]) : @_;
 
-	if (!defined($str)) {
-		return undef;
-	}
-
-	if (!$substr) {
-		$substr = $str;
-		$str    = $_;
-	}
+   return !!0 unless defined($str) && defined($substr);
 
 	my $ret = index($str, $substr, 0) != -1;
 
@@ -635,7 +631,10 @@ Checks if the string starts with the characters in substring
 
   $var = startwith("Hello world", "Hello"); # true
   $var = startwith("Hello world", "H");     # true
+  $var = startwith("Hello world", "");      # true
   $var = startwith("Hello world", "Q");     # false
+  $var = startwith(undef, "Q");             # false
+  $var = startwith("Hello world", undef);   # false
 
   # Also works with grep
   @arr = grep { startswith("X") } @input;
@@ -643,16 +642,9 @@ Checks if the string starts with the characters in substring
 =cut
 
 sub startswith {
-	my ($str, $substr) = @_;
+	my ($str, $substr) = @_ == 1 ? ($_, $_[0]) : @_;
 
-	if (!defined($str)) {
-		return undef;
-	}
-
-	if (!$substr) {
-		$substr = $str;
-		$str    = $_;
-	}
+   return !!0 unless defined($str) && defined($substr);
 
 	my $ret = index($str, $substr, 0) == 0;
 
@@ -665,7 +657,10 @@ Checks if the string ends with the characters in substring
 
   $var = endswith("Hello world", "world");   # true
   $var = endswith("Hello world", "d");       # true
+  $var = endswith("Hello world", "");        # true
   $var = endswith("Hello world", "QQQ");     # false
+  $var = endswith(undef, "QQQ");             # false
+  $var = endswith("Hello world", undef);     # false
 
   # Also works with grep
   @arr = grep { endswith("z") } @input;
@@ -673,16 +668,9 @@ Checks if the string ends with the characters in substring
 =cut
 
 sub endswith {
-	my ($str, $substr) = @_;
+	my ($str, $substr) = @_ == 1 ? ($_, $_[0]) : @_;
 
-	if (!defined($str)) {
-		return undef;
-	}
-
-	if (!$substr) {
-		$substr = $str;
-		$str    = $_;
-	}
+   return !!0 unless defined($str) && defined($substr);
 
 	my $len   = length($substr);
 	my $start = length($str) - $len;

--- a/t/string-contains.t
+++ b/t/string-contains.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+use String::Util ':all';
+use Test::More;
+
+# general purpose variable
+my $val;
+
+#------------------------------------------------------------------------------
+# startswith non-regression
+ok(startswith("0 sales done" , '0'),   "startswith '0'");
+ok(startswith("Quick brown fox" , ''), "startswith empty string");
+ok(startswith('0'),   "startswith '0', with \$_") for '0 sales done';
+ok(!startswith('foo', undef), 'startswith no undef as substring');
+ok(!startswith(undef, 'foo'), 'startswith no substring into undef');
+ok(!startswith(), 'startswith no args nothing back');
+#------------------------------------------------------------------------------
+
+
+#------------------------------------------------------------------------------
+# endswith
+ok(endswith('value is 5.0', '0'),   "endswith '0'");
+ok(endswith('Quick brown fox', ''), "endswith word");
+ok(endswith('0'),   "endswith '0', with \$_") for 'down to 0';
+ok(!endswith('foo', undef), 'endswith no undef as substring');
+ok(!endswith(undef, 'foo'), 'endswith no substring into undef');
+ok(!endswith(), 'endswith no args nothing back');
+#------------------------------------------------------------------------------
+
+
+#------------------------------------------------------------------------------
+# contains
+ok(contains('there are 0 left', '0'), "contains '0'");
+ok(contains('Quick brown fox', ''),   "Contains word 2");
+ok(contains('0'), "contains '0', with \$_") for 'with a 0 inside';
+ok(!contains('foo', undef), 'contains no undef as substring');
+ok(!contains(undef, 'foo'), 'contains no substring into undef');
+ok(!contains(), 'contains no args nothing back');
+#------------------------------------------------------------------------------
+
+
+done_testing();


### PR DESCRIPTION
This patch aims at fixing two corner cases where functions startswith, endswith, and contains currently fail:
- empty substring: consistently with matching against empty regexes;
- `'0'` substring: this was just a bug.

Docs have been estended to clarify the first bullet.

Additionally, the implementation also addresses provision of an undefined substring, returning a false value. Docs have been extended for this as well.

The additional test file aims at providing non-regressions for these behaviors.