### PR TITLE
feat: add occurences function

### DIFF
--- a/lib/String/Util.pm
+++ b/lib/String/Util.pm
@@ -61,6 +61,7 @@ push @EXPORT_OK, qw[
 	rtrim        repeat     unquote   no_space
 	nospace      jsquote    crunchlines
 	file_get_contents		substr_count
+    occurences
 ];
 
 # the following functions return true or false based on their input
@@ -835,7 +836,8 @@ sub substr_count {
 	my ($haystack, $needle) = @_;
 
 	if (!defined($needle) || !defined($haystack)) { return undef; }
-	if ($haystack eq ''   || $needle eq '')       { return 0; }
+    if ($haystack eq ''   || $needle eq '')       { return 0; }
+	if ($haystack eq $needle)                     { return 0; }
 
 	my $pos     = 0;
 	my $matches = 0;
@@ -852,6 +854,66 @@ sub substr_count {
 	}
 
 	return $matches;
+}
+
+=head2 occurences($haystack, $needle)
+
+Returns the indexes for each occurence of $needle in $haystack.
+Returns an arrayref in scalar context and a list, in list context.
+Returns an empty arrayref, or empty list if, $needle is undef, or $haystack is undef.
+Returns an empty arrayref, or empty list if, $needle, or $haystack is an empty string.
+
+  my $occurences = occurences("Perl, is great. Glory to Perl!", "Perl");  # [ 0, 25 ]
+  my @occurences = occurences("Raku is also cool, I like Raku.", "Raku"); # ( 0, 26 )
+
+=cut
+
+sub occurences {
+    my ($haystack, $needle) = @_;
+
+    if (!defined($needle) || !defined($haystack)) {
+        return wantarray ? () : [];
+    }
+
+    if ($haystack eq '' || $needle eq '') {
+        return wantarray ? () : [];
+    }
+
+    if ($needle eq $haystack) {
+        return wantarray ? (0) : [0];
+    }
+
+    my @occurences;
+    my @hchars = split '', $haystack;
+
+    if (length $needle == 1) {
+        foreach my $i (0..$#hchars) {
+            if ($hchars[$i] eq $needle) {
+                push @occurences, $i;            
+            }
+        }
+
+        return wantarray ? @occurences : \@occurences;
+    }
+
+    my @nchars = split '', $needle;
+    foreach my $i (0..$#hchars) {
+        if ($hchars[$i] eq $nchars[0]) {
+            my $match = 1;
+            foreach my $j (1..$#nchars) {
+                if ($hchars[$i + $j] ne $nchars[$j]) {
+                    $match = 0;
+                    last;
+                }
+            }
+
+            if ($match) {
+                push @occurences, $i;
+            }
+        }
+    }
+
+    return wantarray ? @occurences : \@occurences;
 }
 
 

--- a/t/test.t
+++ b/t/test.t
@@ -105,7 +105,6 @@ is(endswith('foo', undef)  , undef , "Second param undef");
 
 ################################################################################
 # contains()
-################################################################################
 
 $val = "Quick brown fox";
 $_   = 7; # Populate $_ to fuzz the tests
@@ -187,6 +186,51 @@ is(substr_count("Perl is really rad", "perl"), 0    , "Substr count word");
 is(substr_count("Perl is really rad", "Perl"), 1    , "Substr count word case sensitive");
 is(substr_count("Perl is really rad", undef) , undef, "Substr count invalid input #1");
 is(substr_count(undef               , "Q")   , undef, "Substr count invalid input #2");
+
+################################################################################
+
+################################################################################
+# occurences()
+################################################################################
+
+{
+    my $occurences = occurences("Perl, is great. Glory to Perl!", "Perl");
+    is(scalar @$occurences ,  2, "Occurences found correct number of occurences");
+    is($occurences->[0]    ,  0, "Occurences finds first");
+    is($occurences->[1]    , 25, "Occurences finds second");
+}
+
+{
+    my @occurences = occurences("Perl, is great. Glory to Perl!", "Perl");
+    is(scalar @occurences ,  2, "Occurences found correct number of occurences (list)");
+    is($occurences[0]     ,  0, "Occurences finds first (list)");
+    is($occurences[1]     , 25, "Occurences finds second (list)");
+}
+
+{
+    my $occurences = occurences(undef, undef);
+    is(scalar @$occurences, 0, "Occurences undef produces correct result?");
+
+    my @occurences = occurences(undef, "foo");
+    is(scalar @occurences, 0, "Occurences undef produces correct result? (list)");
+}
+
+{
+    my $occurences = occurences("Perl Perl Perl Perl Perl Perl Perl", "Perl");
+    my @indexes    = (0, 5, 10, 15, 20, 25, 30);
+    is(scalar @$occurences, 7, "Occurences found correct number of occurences (larger)");
+    for (0..$#indexes) {
+        is($indexes[$_], $occurences->[$_], "Occurences found correct index? [$_]");
+    }
+}
+
+{
+    my $occurences = occurences("abcdefabcdefabcdef", "a");
+    is(scalar @$occurences, 3, "Single letter found right amount of occurences?");
+    is($occurences->[0], 0, "Single letter found correct index for first?");
+    is($occurences->[1], 6, "Single letter found correct index for second?");
+    is($occurences->[2], 12, "Single letter found correct index for third?");
+}
 
 ################################################################################
 


### PR DESCRIPTION
I've often needed an `occurences` function, that finds the indexes of $needle(s) in $haystack.

This is a pretty straight forward solution, and I think fits nicely in this module. Open to feedback. Thanks.

P.S: I also simplified an if statement in `substr_count` as well.